### PR TITLE
Update proposer whitelist docs criteria to reflect real state

### DIFF
--- a/developers/managedoptimisticoraclev2/default-proposer-whitelist.md
+++ b/developers/managedoptimisticoraclev2/default-proposer-whitelist.md
@@ -6,7 +6,7 @@ Risk Labs manages the default proposer whitelist for the ManagedOptimisticOracle
 
 Proposer addresses must meet the two below criteria over the last 6 months:
 
-* 5 or more Polymarket proposals on OptimisticOracleV2 or ManagedOptimisticOracleV2
+* 20 or more Polymarket proposals on OptimisticOracleV2 or ManagedOptimisticOracleV2
 * Proposal accuracy greater than 95% in the last 6 months.
 
 ### How do I get on the whitelist?


### PR DESCRIPTION
Updated criteria to reflect the real state of affairs
- https://blog.uma.xyz/articles/managed-proposers
- The amount of accurate proposals is 20 not 5